### PR TITLE
SimpleMomentSketch: Only apply sinh() to quantiles if useArcSinh is true

### DIFF
--- a/momentsolver/src/main/java/com/github/stanfordfuturedata/momentsketch/SimpleMomentSketch.java
+++ b/momentsolver/src/main/java/com/github/stanfordfuturedata/momentsketch/SimpleMomentSketch.java
@@ -72,7 +72,11 @@ public class SimpleMomentSketch {
         double[] quantiles = new double[fractions.length];
         for (int i = 0; i < fractions.length; i++) {
             double rawQuantile = ms.getQuantile(fractions[i]);
-            quantiles[i] = Math.sinh(rawQuantile);
+            if (useArcSinh) {
+              quantiles[i] = Math.sinh(rawQuantile);
+            } else {
+              quantiles[i] = rawQuantile;
+            }
         }
 
         return quantiles;


### PR DESCRIPTION
Applying Math.sinh() to quantiles skews the results unless useArcSinh is true when producing the moments.